### PR TITLE
Set origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ overwritten.
 
 3. Trim the neck with the `trim_neck.sh` script.
 
+4. Set the origin of the trimmed T1w and brain mask to the centroid of the brain mask.
+
 
 ## Output
 


### PR DESCRIPTION
Set the origin of physical space to the mask centroid. This is an unbiased way to remove large translations in physical space when aligning images from different sessions.