### PR TITLE
BUG: Fixing version info

### DIFF
--- a/build_docker_tag.sh
+++ b/build_docker_tag.sh
@@ -33,9 +33,9 @@ if [[ -z "$gitTag" ]]; then
     exit 1
 fi
 
-# Check that the git tag satisfies the format vX.Y.Z
-if [[ ! $gitTag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Tag $gitTag does not match vX.Y.Z format"
+# Check that the git tag satisfies the format vX.Y.Z or vX.Y.Z-<suffix>
+if [[ ! $gitTag =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+    echo "Tag $gitTag does not match vX.Y.Z[-suffix] format"
     exit 1
 fi
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -43,6 +43,11 @@ def _get_generated_by(existing_generated_by=None):
     generated_by = list()
 
     if existing_generated_by is not None:
+        if isinstance(existing_generated_by, dict):
+            existing_generated_by = [existing_generated_by]
+        elif not isinstance(existing_generated_by, list):
+            raise ValueError("existing_generated_by must be a list of dict or a dict")
+
         generated_by = copy.deepcopy(existing_generated_by)
         for gb in existing_generated_by:
             if gb['Name'] == 'T1wPreprocessing' and gb['Container']['Tag'] == os.environ.get('DOCKER_IMAGE_TAG'):


### PR DESCRIPTION
ENH: Allow vx.y.z-suffix tags

This fix allows us to push a x.y.x-beta container, to ensure tags get written to output BIDS dataset before making an actual release.